### PR TITLE
MEP110

### DIFF
--- a/myhdl/conversion/_analyze.py
+++ b/myhdl/conversion/_analyze.py
@@ -43,7 +43,7 @@ from myhdl.conversion._misc import (_error, _access, _kind,
 from myhdl._extractHierarchy import _isMem, _getMemInfo, _UserCode
 from myhdl._Signal import _Signal, _WaiterList
 from myhdl._ShadowSignal import _ShadowSignal, _SliceSignal, _TristateDriver
-from myhdl._util import _isTupleOfInts, _flatten, _makeAST
+from myhdl._util import _isTupleOfInts, _flatten, _makeAST, _isTupleOfFloats
 from myhdl._resolverefs import _AttrRefTransformer
 from myhdl._compat import builtins, integer_types, long, string_types, PY2
 from myhdl.numeric._conversion import (numeric_functions_dict,
@@ -1077,7 +1077,7 @@ class _AnalyzeVisitor(ast.NodeVisitor, _ConversionMixin):
             node.obj = obj
         elif n in self.tree.symdict:
             node.obj = self.tree.symdict[n]
-            if _isTupleOfInts(node.obj):
+            if _isTupleOfInts(node.obj) or _isTupleOfFloats(node.obj):
                 node.obj = _Rom(node.obj)
                 self.tree.hasRom = True
             elif _isMem(node.obj):

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1757,7 +1757,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
     def writeDeclarations(self):
         if self.tree.hasPrint:
             self.writeline()
-            self.write("variable L: line;")
+            self.write("variable print: line;")
         for name, obj in self.tree.vardict.items():
             if isinstance(obj, _loopInt):
                 continue  # hack for loop vars
@@ -2560,7 +2560,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         argnr = 0
         for s in node.format:
             if isinstance(s, str):
-                self.write('write(L, string\'("%s"));' % s)
+                self.write('write(print, string\'("%s"));' % s)
             else:
                 a = node.args[argnr]
                 argnr += 1
@@ -2573,7 +2573,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
                         a.vhd = vhd_boolean()
                     elif isinstance(a.vhdOri, vhd_enum):
                         a.vhd = vhd_string()
-                self.write("write(L, ")
+                self.write("write(print, ")
                 self.context = _context.PRINT
                 self.visit(a)
                 self.context = None
@@ -2584,7 +2584,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
                 self.write(")")
                 self.write(';')
             self.writeline()
-        self.write("writeline(output, L);")
+        self.write("writeline(output, print);")
 
     def visit_Raise(self, node):
         self.write('assert False report "End of Simulation" severity Failure;')


### PR DESCRIPTION
In order to avoid errors due the use of a variable called l or L, the
variable name has been modified. The name print has been chosen as it
can be considered a Python reserved word, and it is not reserved in
VHDL.
