### PR TITLE
Modified the slice assignment

### DIFF
--- a/myhdl/test/conversion/numeric/test_numass.py
+++ b/myhdl/test/conversion/numeric/test_numass.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function
 from random import randrange
 
 from myhdl import Signal, uintba, sintba, instance, delay, conversion
-from myhdl.test.conftest import bug
 
 
 def NumassBench():
@@ -51,6 +50,6 @@ def NumassBench():
 
     return check
 
-@bug("Unsigned result pending to be solved", "vhdl")
+
 def test_numass():
     assert conversion.verify(NumassBench) == 0


### PR DESCRIPTION
The conversion to unsigned of the slices has problems with sfixed if
one of the index is negative. For this reason, this feature has only
been maintained for intbv to ensure compatibility with the base MyHDL.
