### PR TITLE
Changing the low of sfixed slices

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -2719,6 +2719,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
                 node.value.vhd.from_intbv:
             pre = pre + "unsigned("
             suf = ")" + suf
+        elif isinstance(node.value.vhd, vhd_sfixed) and \
+                isinstance(node.ctx, ast.Load):
+            pre = pre + "slice("
+            suf = ")" + suf
         self.write(pre)
         self.visit(node.value)
         lower, upper = node.slice.lower, node.slice.upper

--- a/myhdl/conversion/_toVHDLPackage.py
+++ b/myhdl/conversion/_toVHDLPackage.py
@@ -154,7 +154,9 @@ package pck_myhdl_%(version)s is
 
     function c_str2f (value: std_logic_vector) return sfixed;
 
-    function tern_op(cond: boolean; if_true: sfixed; if_false: sfixed) return sfixed;
+    function tern_op (cond: boolean; if_true: sfixed; if_false: sfixed) return sfixed;
+
+    function slice (arg: sfixed) return signed;
 """
     result += """
 end pck_myhdl_%(version)s;
@@ -474,6 +476,13 @@ package body pck_myhdl_%(version)s is
             return if_false;
         end if;
     end function tern_op;
+
+    function slice (arg: sfixed) return signed is
+        variable result : sfixed (arg'length -1 downto 0) ;
+    begin
+        result := arg;
+        return signed(result);
+    end function slice;
 
 """
     result += """

--- a/myhdl/test/conversion/numeric/test_numass.py
+++ b/myhdl/test/conversion/numeric/test_numass.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, print_function
 
 from random import randrange
 
-from myhdl import Signal, uintba, sintba, instance, delay, conversion
+from myhdl import Signal, uintba, sintba, sfixba, \
+    instance, delay, conversion
 
 
 def NumassBench():
@@ -10,8 +11,10 @@ def NumassBench():
     q = Signal(uintba(1, 40))
     r = Signal(sintba(1, 9))
     s = Signal(sintba(1, 41))
-    PBIGINT = randrange(2**34, 2**40)
-    NBIGINT = -randrange(2**34, 2**40)
+    t = Signal(sfixba(1, 5, -4))
+    u = Signal(sfixba(1, 31, -10))
+    PBIGINT = Signal(uintba(randrange(2**34, 2**40)))
+    NBIGINT = Signal(sintba(-randrange(2**34, 2**40)))
 
     @instance
     def check():
@@ -19,34 +22,50 @@ def NumassBench():
         q.next = 0
         r.next = 0
         s.next = 0
+        t.next[:] = 0
+        u.next[:] = 0
         yield delay(10)
-        print("%d %d %d %d" % (p, q, r, s))
+        print("%d %d %d %d %s %s" % (p, q, r, s, t, u))
         p.next = 1
         q.next = 1
         r.next = 1
         s.next = 1
+        t.next[:] = 1
+        u.next[:] = 1
         yield delay(10)
-        print("%d %d %d %d" % (p, q, r, s))
+        print("%d %d %d %d %s %s" % (p, q, r, s, t, u))
         p.next = 2
         q.next = 2
         r.next = -2
         s.next = -2
+        t.next[:] = -2
+        u.next[:] = -2
         yield delay(10)
-        print("%d %d %d %d" % (p, q, r, s))
+        print("%d %d %d %d %s %s" % (p, q, r, s, t, u))
         p.next = 255
         q.next = 246836311517
         r.next = 255
         s.next = -246836311517
+        t.next[:] = 255
+        u.next[:] = -246836311517
         yield delay(10)
-        print("%d %d %d %d %d %d" % (p, q[40:20], q[20:0], r,
-                                     s[41:20], s[20:0]))
+        print("%d %d %d %d %d %d %s %s %s" %
+              (p, q[40:20], q[20:0], r,
+               s[41:20], s[20:0], t, u[31:10], u[10:-10]))
+        print("%s %s" % (s[41:20] >= s[20:0],
+                         u[31:10] >= u[10:-10]))
         p.next = 254
         q.next = PBIGINT
         r.next = -256
         s.next = NBIGINT
+        t.next[:] = -256
+        u.next[:] = NBIGINT
         yield delay(10)
-        print("%d %d %d %d %d %d" % (p, q[40:20], q[20:0], r,
-                                     s[41:20], s[20:0]))
+        print("%d %d %d %d %d %d %s %s %s" %
+              (p, q[40:20], q[20:0], r,
+               s[41:20], s[20:0], t, u[31:10], u[10:-10]))
+        print("%s %s" % (s[41:20] >= s[20:0],
+                         u[31:10] >= u[10:-10]))
 
     return check
 


### PR DESCRIPTION
To avoid errors with slices, the origin of any slice for sfixed values
have been defined as zero. For the function slice has been defined,
that makes this translation.
